### PR TITLE
Now plugin works with Xcode 6.3.2

### DIFF
--- a/ExtractLocalization/Plugin/Principal Class/ExtractLocalization.m
+++ b/ExtractLocalization/Plugin/Principal Class/ExtractLocalization.m
@@ -24,7 +24,7 @@ static id sharedPlugin = nil;
 
 -(id)initWithBundle:(NSBundle *)bundle{
     if (self = [super init]) {
-        [self createMenuExtractLocalization];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createMenuExtractLocalization) name:NSApplicationDidFinishLaunchingNotification object:nil];
     }
     return self;
 }

--- a/ExtractLocalization/Plugin/Principal Class/ExtractLocalization.m
+++ b/ExtractLocalization/Plugin/Principal Class/ExtractLocalization.m
@@ -136,4 +136,8 @@ static id sharedPlugin = nil;
     return NO;
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
+}
+
 @end


### PR DESCRIPTION
Now plugin works with Xcode 6.3.2

https://github.com/viniciusmo/extract-localizable-string-plugin-xcode/issues/13